### PR TITLE
Add anonymous option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,42 @@
 # eslint-plugin-require-jsdoc
-This is a plugin for [eslint](http://eslint.org/) for enforcing all FUNCTIONS should have jsdoc.   
-I had to write this because the (valid-jsdoc)(http://eslint.org/docs/rules/valid-jsdoc) rule in eslint did not help me to enforce that the functions MSUT have a jsdoc.Instead it validated the jsdoc. So for the best results **use both together** to make sure **jsdoc is a must** for all methods and **they are valid**.
 
-##usage
-Follow the instructions [here](http://eslint.org/docs/user-guide/configuring#configuring-plugins)
+This is a plugin for [eslint](http://eslint.org/) for enforcing all FUNCTIONS
+should have jsdoc. You may optionally disable this for `anonymous` functions.
 
-eg:   
-(in your eslintrc)   
+I had to write this because the [valid-jsdoc](http://eslint.org/docs/rules/valid-jsdoc)
+rule in eslint did not help me to enforce that the functions MSUT have a jsdoc.
+
+Instead it validated the jsdoc. So for the best results **use both together** to
+make sure **jsdoc is a must** for all methods and **they are valid**.
+
+## Usage
+
+To enable to plugin, update your `.eslintrc` like so:
+
 ```json
-  "plugins": [   
-    "require-jsdoc"   
+  "plugins": [
+    "require-jsdoc"
   ],
-  "rules": {   
-    "require-jsdoc": 2,  
-    "valid-jsdoc": 2   
-  }   
-```  
+  "rules": {
+    "require-jsdoc/require-jsdoc": [2,{"anonymous": false}]
+  }
+```
 
-##future
-In future I hope to add jsdoc validation as well. Hence two rules can be avoided.   
-Please let me know your feedbacks.
+You may also want to enable [valid-jsdoc](http://eslint.org/docs/rules/valid-jsdoc.html)
+
+```json
+  "rules": {
+    "valid-jsdoc": 2
+  }
+```
+
+Further information can be found at Eslint's [configuration](http://eslint.org/docs/user-guide/configuring#configuring-plugins)
+guide.
+
+The `anonymous` option refers to whether or not you want to validate anonymous
+functions such as callbacks or closures.
+
+## Future
+
+In future I hope to add jsdoc validation as well. Hence two rules can be
+avoided. Please let me know your feedback.

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -2,7 +2,10 @@
 
 module.exports = function (context) {
 
-  var RETURN_REGEX = /@return(s)?/;
+  var configuration = context.options[0] || {};
+  var parseAnonymousFunctions = !!configuration.anonymous;
+
+  var RETURN_REGEX = /@return(s)?/g;
   var PARAM_REGEX = /@param/g;
 
   /**
@@ -40,12 +43,14 @@ module.exports = function (context) {
   function displayWarning(error, node, id) {
     switch (error) {
       case 'no-return':
-            context.report(node, 'Missing @return description in the jsdoc for ' + id.name);
+            context.report(node, 'Missing @return statement in the jsdoc for ' + id.name);
             break;
       case 'no-param':
-            context.report(node, 'Missing @param description in the jsdoc for ' + id.name);
+            context.report(node, 'Missing @param statement in the jsdoc for ' + id.name);
             break;
-      default: context.report(node, 'Missing @jsdoc for ' + id.name);
+      case 'no-jsdoc':
+            context.report(node, 'Missing @jsdoc for ' + id.name);
+            break;
     }
   }
 
@@ -64,6 +69,12 @@ module.exports = function (context) {
     'FunctionDeclaration': function(node){
       var comment = getCommentText(node);
       var numParams;
+      var name = node.id && node.id.name;
+
+      if (!name && !parseAnonymousFunctions) {
+        return;
+      }
+
       if (!comment) {
         return displayWarning('no-jsdoc', node, node.id);
       }
@@ -81,6 +92,11 @@ module.exports = function (context) {
       var commentNode;
       var refNode;
       var key;
+      var name = node.id && node.id.name;
+
+      if (!name && !parseAnonymousFunctions) {
+        return;
+      }
 
       numParams = node.params ? node.params.length : 0;
 
@@ -116,6 +132,19 @@ module.exports = function (context) {
       if (!hasEnoughParamStatements(comment, numParams)) {
         displayWarning('no-param', node, refNode[key]);
       }
+
     }
   };
 };
+
+module.exports.schema = [
+  {
+    "type": "object",
+    "properties": {
+      "anonymous": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  }
+];


### PR DESCRIPTION
Currently the plugin attempts to validate every function that it
encounters. This PR modifies that default behaviour to only functions
that are not `anonymous`.

It also updates some of the documentation `README.md` as well as the
warning messages for missing statements.
