### PR TITLE
Fix issue with leading line comments

### DIFF
--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -55,7 +55,18 @@ module.exports = function (context) {
    * @returns {String} extracted comment for node
    */
   function getCommentText(node) {
-    var comment = context.getComments(node).leading[0] && context.getComments(node).leading[0].value || '';
+    var comment = '';
+    var blockComment;
+    var lineComment;
+    context.getComments(node).leading.forEach(function(item) {
+      if(item.type === 'Block' && item.value) {
+        blockComment = item.value;
+      };
+       if(item.type === 'Line' && item.value) {
+        lineComment = item.value;
+      };
+    });
+    comment = blockComment || lineComment;
     comment = comment.replace(/\s/g, '');
     return comment;
   }

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -82,7 +82,7 @@ module.exports = function (context) {
         lineComment = item.value;
       };
     });
-    comment = blockComment || lineCommen || '';
+    comment = blockComment || lineComment || '';
     comment = comment.replace(/\s/g, '');
     return comment;
   }

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -6,6 +6,22 @@ module.exports = function (context) {
   var PARAM_REGEX = /@param/g;
 
   /**
+   * Checks the function name against the list of ignored functions
+   * @param  {Object}  node AST node
+   * @returns {Boolean}      Returns true if the function should be ignored
+   */
+  function isIgnored(node) {
+    if (node && node.id && node.id.name) {
+      var funcName = node.id.name;
+      var configuration = context.options[0] || {};
+      var ignored = configuration.ignore || [];
+      return ignored.indexOf(funcName) >= 0;
+    } else {
+      return false;
+    }
+  }
+
+  /**
    * Check for the existence for the @return statement
    * @param  {String}  comment jsdoc comment
    * @returns {Boolean} Returns true if @return/returns exists in the comment
@@ -59,10 +75,10 @@ module.exports = function (context) {
     var blockComment;
     var lineComment;
     context.getComments(node).leading.forEach(function(item) {
-      if(item.type === 'Block' && item.value) {
+      if (item.type === 'Block' && item.value) {
         blockComment = item.value;
       };
-       if(item.type === 'Line' && item.value) {
+      if (item.type === 'Line' && item.value) {
         lineComment = item.value;
       };
     });
@@ -73,6 +89,7 @@ module.exports = function (context) {
 
   return {
     'FunctionDeclaration': function(node){
+      if (isIgnored(node)) return;
       var comment = getCommentText(node);
       var numParams;
       if (!comment) {
@@ -87,6 +104,7 @@ module.exports = function (context) {
       }
     },
     'FunctionExpression': function(node){
+      if (isIgnored(node)) return;
       var comment;
       var numParams;
       var commentNode;

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -55,18 +55,18 @@ module.exports = function (context) {
    * @returns {String} extracted comment for node
    */
   function getCommentText(node) {
-    var comment = '';
+    var comment;
     var blockComment;
     var lineComment;
     context.getComments(node).leading.forEach(function(item) {
-      if(item.type === 'Block' && item.value) {
+      if (item.type === 'Block' && item.value) {
         blockComment = item.value;
       };
-       if(item.type === 'Line' && item.value) {
+       if (item.type === 'Line' && item.value) {
         lineComment = item.value;
       };
     });
-    comment = blockComment || lineComment;
+    comment = blockComment || lineCommen || '';
     comment = comment.replace(/\s/g, '');
     return comment;
   }


### PR DESCRIPTION
There seems to be an issue with picking up the last line comment and ignoring the leading block comment.

When I run the linter on the following code, `context.getComments(node).leading[0]`contains "This declaration needs a comment"

```
'use strict';

var var1 = null; //This declaration needs a comment

/**
 * Func1 desc.
 * 
 * @param  {string} param1 Param1 desc.
 * @return {Object} Just an object
 * 
 */
function func1(param1) {
    return null;
}
```
